### PR TITLE
fs: ability to filter xattr when copying directory

### DIFF
--- a/fs/copy_linux.go
+++ b/fs/copy_linux.go
@@ -104,21 +104,24 @@ func copyFileContent(dst, src *os.File) error {
 	return nil
 }
 
-func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
+func copyXAttrs(dst, src string, excludes map[string]struct{}, errorHandler XAttrErrorHandler) error {
 	xattrKeys, err := sysx.LListxattr(src)
 	if err != nil {
 		e := errors.Wrapf(err, "failed to list xattrs on %s", src)
-		if xeh != nil {
-			e = xeh(dst, src, "", e)
+		if errorHandler != nil {
+			e = errorHandler(dst, src, "", e)
 		}
 		return e
 	}
 	for _, xattr := range xattrKeys {
+		if _, exclude := excludes[xattr]; exclude {
+			continue
+		}
 		data, err := sysx.LGetxattr(src, xattr)
 		if err != nil {
 			e := errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
-			if xeh != nil {
-				if e = xeh(dst, src, xattr, e); e == nil {
+			if errorHandler != nil {
+				if e = errorHandler(dst, src, xattr, e); e == nil {
 					continue
 				}
 			}
@@ -126,8 +129,8 @@ func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 		}
 		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
 			e := errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
-			if xeh != nil {
-				if e = xeh(dst, src, xattr, e); e == nil {
+			if errorHandler != nil {
+				if e = errorHandler(dst, src, xattr, e); e == nil {
 					continue
 				}
 			}

--- a/fs/copy_unix.go
+++ b/fs/copy_unix.go
@@ -67,21 +67,24 @@ func copyFileContent(dst, src *os.File) error {
 	return err
 }
 
-func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
+func copyXAttrs(dst, src string, excludes map[string]struct{}, errorHandler XAttrErrorHandler) error {
 	xattrKeys, err := sysx.LListxattr(src)
 	if err != nil {
 		e := errors.Wrapf(err, "failed to list xattrs on %s", src)
-		if xeh != nil {
-			e = xeh(dst, src, "", e)
+		if errorHandler != nil {
+			e = errorHandler(dst, src, "", e)
 		}
 		return e
 	}
 	for _, xattr := range xattrKeys {
+		if _, exclude := excludes[xattr]; exclude {
+			continue
+		}
 		data, err := sysx.LGetxattr(src, xattr)
 		if err != nil {
 			e := errors.Wrapf(err, "failed to get xattr %q on %s", xattr, src)
-			if xeh != nil {
-				if e = xeh(dst, src, xattr, e); e == nil {
+			if errorHandler != nil {
+				if e = errorHandler(dst, src, xattr, e); e == nil {
 					continue
 				}
 			}
@@ -89,8 +92,8 @@ func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
 		}
 		if err := sysx.LSetxattr(dst, xattr, data, 0); err != nil {
 			e := errors.Wrapf(err, "failed to set xattr %q on %s", xattr, dst)
-			if xeh != nil {
-				if e = xeh(dst, src, xattr, e); e == nil {
+			if errorHandler != nil {
+				if e = errorHandler(dst, src, xattr, e); e == nil {
 					continue
 				}
 			}

--- a/fs/copy_unix_test.go
+++ b/fs/copy_unix_test.go
@@ -1,0 +1,87 @@
+// +build !windows
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package fs
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/containerd/continuity/fs/fstest"
+	"github.com/containerd/continuity/sysx"
+)
+
+func assertXAttr(t *testing.T, dir, xattr, xval string, xerr error) {
+	t.Helper()
+	value, err := sysx.Getxattr(dir, xattr)
+	switch {
+	case xerr == nil && err != nil:
+		t.Errorf("err=%v; expected val=%s", err, xval)
+	case xerr == nil && err == nil && string(value) != xval:
+		t.Errorf("val=%s; expected val=%s", value, xval)
+	case xerr != nil && err != xerr:
+		t.Errorf("val=%s, err=%v; expected err=%v", value, err, xerr)
+	}
+}
+
+func TestCopyDirWithXAttrExcludes(t *testing.T) {
+	src, err := ioutil.TempDir("", "test-copy-src-with-xattr-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(src)
+
+	if err := fstest.Apply(
+		fstest.SetXAttr(".", "user.test-1", "one"),
+		fstest.SetXAttr(".", "user.test-2", "two"),
+		fstest.SetXAttr(".", "user.test-x", "three-four-five"),
+	).Apply(src); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("none", func(t *testing.T) {
+		dst, err := ioutil.TempDir("", "test-copy-dst-with-xattr-exclude-none-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(dst)
+		err = CopyDir(dst, src, WithXAttrExclude())
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertXAttr(t, dst, "user.test-1", "one", nil)
+		assertXAttr(t, dst, "user.test-2", "two", nil)
+		assertXAttr(t, dst, "user.test-x", "three-four-five", nil)
+	})
+
+	t.Run("some", func(t *testing.T) {
+		dst, err := ioutil.TempDir("", "test-copy-dst-with-xattr-exclude-some-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(dst)
+		err = CopyDir(dst, src, WithXAttrExclude("user.test-x"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertXAttr(t, dst, "user.test-1", "one", nil)
+		assertXAttr(t, dst, "user.test-2", "two", nil)
+		assertXAttr(t, dst, "user.test-x", "", sysx.ENODATA)
+	})
+}

--- a/fs/copy_windows.go
+++ b/fs/copy_windows.go
@@ -40,7 +40,7 @@ func copyFileContent(dst, src *os.File) error {
 	return err
 }
 
-func copyXAttrs(dst, src string, xeh XAttrErrorHandler) error {
+func copyXAttrs(dst, src string, excludes map[string]struct{}, errorHandler XAttrErrorHandler) error {
 	return nil
 }
 

--- a/fs/fstest/file_unix.go
+++ b/fs/fstest/file_unix.go
@@ -29,7 +29,8 @@ import (
 // SetXAttr sets the xatter for the file
 func SetXAttr(name, key, value string) Applier {
 	return applyFn(func(root string) error {
-		return sysx.LSetxattr(name, key, []byte(value), 0)
+		path := filepath.Join(root, name)
+		return sysx.LSetxattr(path, key, []byte(value), 0)
 	})
 }
 


### PR DESCRIPTION
Add fs.WithXAttrExcludes functional option for fs.CopyDir that passes
down a list of xattr keys to filter out when copying.

This ought to allow for a fix for https://github.com/containerd/containerd/issues/5090

Signed-off-by: Jacob Blain Christen <jacob@rancher.com>

Co-authored-by: Samuel Karp <samuelkarp@users.noreply.github.com>